### PR TITLE
Disable actions in elements with contenteditable

### DIFF
--- a/Keyconfig/js/chrome_keyconfig.js
+++ b/Keyconfig/js/chrome_keyconfig.js
@@ -1225,10 +1225,13 @@
       }
       var target = evt.target;
       var isTextedit = false;
-      if ('selectionStart' in target && target.disabled !== true) {
+      if (('selectionStart' in target || target.isContentEditable) && target.disabled !== true) {
         try {
           var s = target.selectionStart;
           if (KeyConfig.config.chrome_vim) {
+            if (s === undefined && target.isContentEditable) {
+              return;
+            }
             if (KeyConfig.vimActionSet === 'vim_normal_actions') {
               evt.preventDefault();
             }


### PR DESCRIPTION
contenteditable属性を持つ要素において、アクションが動作しないように変更しました。
なお、キャレットの移動が正しく動かないため、Vi like actionsには未対応です。モード切り替えなどのエラーにならないコマンドも含めて、すべて無視するようにしています。
