### PR TITLE
Suppress reloading of the back action

### DIFF
--- a/Keyconfig/js/chrome_keyconfig.js
+++ b/Keyconfig/js/chrome_keyconfig.js
@@ -326,9 +326,15 @@
   };
   var ACTION = {
     "back": function (arg) {
+      if (history.length == 1) {
+        return;
+      }
       history.go(Math.max(-arg.times, -history.length + 1));
     },
     "fastback": function (arg) {
+      if (history.length == 1) {
+        return;
+      }
       history.go(-history.length + 1);
     },
     "forward": function (arg) {


### PR DESCRIPTION
ページを開いてから一度もページ遷移していない状態でbackやfastbackアクションを実行すると、リロードされてしまうようです。
history.length == 1の時に、history.goの引数が0になるのが原因のようなので、チェックして弾くように変更しました。

よろしくお願いします。
